### PR TITLE
feat: Display banner for rows updated since last visit

### DIFF
--- a/datasette_chronicle/static/datasette_chronicle.js
+++ b/datasette_chronicle/static/datasette_chronicle.js
@@ -1,0 +1,105 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const maxVersion = window.datasette_chronicle_max_version;
+    const databaseName = window.datasette_chronicle_database_name;
+    const tableName = window.datasette_chronicle_table_name;
+
+    if (typeof maxVersion === 'undefined' || typeof databaseName === 'undefined' || typeof tableName === 'undefined') {
+        // If any of these are undefined, the necessary data wasn't injected.
+        // This might happen on pages where extra_body_script isn't called or doesn't add these.
+        console.log('Datasette Chronicle: Missing required global variables. Exiting.');
+        return;
+    }
+
+    const localStorageKey = `chronicle_last_seen_info_${databaseName}_${tableName}`;
+    let storedInfoText = localStorage.getItem(localStorageKey);
+    let storedInfo = {};
+
+    if (storedInfoText) {
+        try {
+            storedInfo = JSON.parse(storedInfoText);
+        } catch (e) {
+            console.error('Datasette Chronicle: Error parsing storedInfo from localStorage', e);
+            storedInfo = {}; // Reset to default if parsing fails
+        }
+    }
+
+    const lastSeenVersion = storedInfo.version;
+    const lastSeenTimestamp = storedInfo.timestamp;
+
+    function displayBanner(count, timeSinceText) {
+        const banner = document.createElement('div');
+        banner.className = 'chronicle-notification-banner'; // Use the class defined in extra_head_html
+        let message = `${count} row${count > 1 ? 's' : ''} updated`;
+        if (timeSinceText) {
+            message += ` since your last visit ${timeSinceText}.`;
+        } else {
+            message += '.'; // Should ideally not happen if timeSinceText is always calculated
+        }
+        
+        banner.textContent = message;
+
+        // Try to prepend to a common Datasette content container, fallback to body
+        const mainContent = document.querySelector('.table-wrapper') || document.querySelector('div[role="main"]') || document.querySelector('#main-content');
+        if (mainContent && mainContent.firstChild) {
+            mainContent.insertBefore(banner, mainContent.firstChild);
+        } else if (document.body.firstChild) {
+            document.body.insertBefore(banner, document.body.firstChild);
+        } else {
+            document.body.appendChild(banner);
+        }
+    }
+
+    if (typeof lastSeenVersion === 'undefined' || maxVersion > lastSeenVersion) {
+        if (typeof lastSeenVersion !== 'undefined') {
+            // This means it's not the first visit AND there are new changes.
+            const apiUrl = `./${encodeURIComponent(tableName)}.json?_since=${encodeURIComponent(lastSeenVersion)}&_extra=count&_size=0`;
+            
+            fetch(apiUrl)
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
+                    return response.json();
+                })
+                .then(data => {
+                    if (data && data.ok && data.count > 0) {
+                        const count = data.count;
+                        let timeSince = "";
+                        if (lastSeenTimestamp) {
+                            const diffMs = new Date().getTime() - lastSeenTimestamp;
+                            const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+                            const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+                            if (diffDays > 0) {
+                                timeSince = `${diffDays} day${diffDays > 1 ? 's' : ''} ago`;
+                            } else if (diffHours > 0) {
+                                timeSince = `${diffHours} hour${diffHours > 1 ? 's' : ''} ago`;
+                            } else {
+                                timeSince = "recently";
+                            }
+                        } else {
+                            // If no lastSeenTimestamp, perhaps just say "new changes"
+                            timeSince = "recently (new changes detected)";
+                        }
+                        displayBanner(count, timeSince);
+                    }
+                })
+                .catch(error => {
+                    console.error('Datasette Chronicle: Error fetching chronicle count:', error);
+                });
+        }
+        // Always update localStorage if it's the first visit or if there are new versions
+        localStorage.setItem(localStorageKey, JSON.stringify({
+            version: maxVersion,
+            timestamp: new Date().getTime()
+        }));
+
+    } else {
+        // This case is when maxVersion <= lastSeenVersion.
+        // If it's the very first visit and maxVersion is 0 (empty chronicle table),
+        // we still want to record this visit so subsequent additions show up as new.
+        // The condition `typeof lastSeenVersion === 'undefined'` is handled by the `if` block above.
+        // So, this `else` block implies `lastSeenVersion` is defined and `maxVersion <= lastSeenVersion`.
+        // No action needed here other than what might already be done (e.g. ensuring timestamp updated if desired, but current logic updates timestamp only on new versions or first visit)
+    }
+});

--- a/tests/test_chronicle.py
+++ b/tests/test_chronicle.py
@@ -1,6 +1,9 @@
 from datasette.app import Datasette
 import pytest
 import sqlite_utils
+import re
+import sqlite_chronicle # For direct chronicle manipulation in Playwright tests
+import time # For timestamp comparisons, if necessary
 
 
 @pytest.mark.asyncio
@@ -174,3 +177,279 @@ async def test_upgrades_existing_chronicle_tables_on_startup(tmpdir):
         "__updated_ms": int,
         "__version": int,
     }
+
+
+@pytest.mark.asyncio
+async def test_chronicle_extra_js_urls(tmpdir):
+    db_path = str(tmpdir / "test_js.db")
+    datasette = Datasette([db_path], metadata={
+        "plugins": {
+            "datasette-chronicle": {
+                "foo": "bar" # Ensure plugin is loaded
+            }
+        }
+    })
+    db = sqlite_utils.Database(db_path)
+    db["items"].insert_all([{"id": 1, "name": "Item 1"}], pk="id")
+
+    # Enable chronicle for "items" table
+    # Need actor and CSRF token
+    cookies = {"ds_actor": datasette.sign({"a": {"id": "root"}}, "actor")}
+    response_for_csrf = await datasette.client.get("/test_js/items", cookies=cookies)
+    assert response_for_csrf.status_code == 200
+    csrftoken = response_for_csrf.cookies["ds_csrftoken"]
+    cookies["ds_csrftoken"] = csrftoken
+
+    enable_response = await datasette.client.post(
+        "/-/enable-chronicle/test_js/items",
+        data={"csrftoken": csrftoken},
+        cookies=cookies,
+    )
+    assert enable_response.status_code == 302 # Redirects after enabling
+
+    # Check table page when chronicle is enabled
+    response_enabled = await datasette.client.get("/test_js/items", cookies=cookies)
+    assert response_enabled.status_code == 200
+    assert '<script src="/-/static-plugins/datasette-chronicle/datasette_chronicle.js"></script>' in response_enabled.text
+
+    # Disable chronicle for "items" table
+    disable_response = await datasette.client.post(
+        "/-/disable-chronicle/test_js/items",
+        data={"csrftoken": csrftoken},
+        cookies=cookies,
+    )
+    assert disable_response.status_code == 302
+
+    # Check table page when chronicle is disabled
+    response_disabled = await datasette.client.get("/test_js/items", cookies=cookies)
+    assert response_disabled.status_code == 200
+    assert '<script src="/-/static-plugins/datasette-chronicle/datasette_chronicle.js"></script>' not in response_disabled.text
+
+    # Check a table where chronicle was never enabled
+    db["other_items"].insert_all([{"id": 1, "name": "Other Item 1"}], pk="id")
+    response_never_enabled = await datasette.client.get("/test_js/other_items", cookies=cookies)
+    assert response_never_enabled.status_code == 200
+    assert '<script src="/-/static-plugins/datasette-chronicle/datasette_chronicle.js"></script>' not in response_never_enabled.text
+
+
+@pytest.mark.asyncio
+async def test_chronicle_extra_head_html(tmpdir):
+    db_path = str(tmpdir / "test_head.db")
+    datasette = Datasette([db_path], metadata={
+        "plugins": {
+            "datasette-chronicle": {
+                "foo": "bar" 
+            }
+        }
+    })
+    db = sqlite_utils.Database(db_path)
+    db["products"].insert_all([{"id": 1, "sku": "PROD001"}], pk="id")
+
+    cookies = {"ds_actor": datasette.sign({"a": {"id": "root"}}, "actor")}
+    response_for_csrf = await datasette.client.get("/test_head/products", cookies=cookies)
+    csrftoken = response_for_csrf.cookies["ds_csrftoken"]
+    cookies["ds_csrftoken"] = csrftoken
+
+    await datasette.client.post(
+        "/-/enable-chronicle/test_head/products",
+        data={"csrftoken": csrftoken},
+        cookies=cookies,
+    )
+
+    response_enabled = await datasette.client.get("/test_head/products", cookies=cookies)
+    assert response_enabled.status_code == 200
+    assert "<style>" in response_enabled.text
+    assert ".chronicle-notification-banner" in response_enabled.text
+
+    await datasette.client.post(
+        "/-/disable-chronicle/test_head/products",
+        data={"csrftoken": csrftoken},
+        cookies=cookies,
+    )
+    response_disabled = await datasette.client.get("/test_head/products", cookies=cookies)
+    assert response_disabled.status_code == 200
+    assert "<style>" not in response_disabled.text
+    assert ".chronicle-notification-banner" not in response_disabled.text
+
+
+@pytest.mark.asyncio
+async def test_chronicle_extra_body_script(tmpdir):
+    db_path = str(tmpdir / "test_body.db")
+    datasette = Datasette([db_path], metadata={
+        "plugins": {
+            "datasette-chronicle": {
+                "foo": "bar"
+            }
+        }
+    })
+    db = sqlite_utils.Database(db_path)
+    table_name = "orders"
+    db[table_name].insert_all([{"id": 1, "val": "A"}], pk="id")
+
+    cookies = {"ds_actor": datasette.sign({"a": {"id": "root"}}, "actor")}
+    response_for_csrf = await datasette.client.get(f"/test_body/{table_name}", cookies=cookies)
+    csrftoken = response_for_csrf.cookies["ds_csrftoken"]
+    cookies["ds_csrftoken"] = csrftoken
+
+    # Enable chronicle
+    await datasette.client.post(
+        f"/-/enable-chronicle/test_body/{table_name}",
+        data={"csrftoken": csrftoken},
+        cookies=cookies,
+    )
+
+    # Initial state (after enabling, version should be 1 due to initial insert into chronicle)
+    # sqlite-chronicle auto-inserts existing rows into chronicle table with version 1 upon enabling
+    response = await datasette.client.get(f"/test_body/{table_name}", cookies=cookies)
+    assert response.status_code == 200
+    
+    # Version 1 from the initial population of _chronicle_orders from existing 'orders' table
+    expected_max_version = 1 
+    assert f'window.datasette_chronicle_max_version = {expected_max_version};' in response.text
+    assert f'window.datasette_chronicle_database_name = "test_body";' in response.text
+    assert f'window.datasette_chronicle_table_name = "{table_name}";' in response.text
+    
+    chronicle_rows = list(db.query(f"SELECT MAX(__version) as max_v FROM _chronicle_{table_name}"))
+    assert chronicle_rows[0]["max_v"] == expected_max_version
+
+    # Add more data to increment version
+    db[table_name].insert({"id": 2, "val": "B"}) # Version 2
+    db[table_name].update(1, {"val": "A_updated"}) # Version 3
+
+    response_updated = await datasette.client.get(f"/test_body/{table_name}", cookies=cookies)
+    assert response_updated.status_code == 200
+    expected_max_version_updated = 3
+    assert f'window.datasette_chronicle_max_version = {expected_max_version_updated};' in response_updated.text
+    
+    chronicle_rows_updated = list(db.query(f"SELECT MAX(__version) as max_v FROM _chronicle_{table_name}"))
+    assert chronicle_rows_updated[0]["max_v"] == expected_max_version_updated
+
+    # Test with an empty chronicle table (enabled but no CUD operations yet on original table)
+    empty_table_name = "empty_stuff"
+    db[empty_table_name].create({"id": int, "name": str}, pk="id")
+    await datasette.client.post(
+        f"/-/enable-chronicle/test_body/{empty_table_name}",
+        data={"csrftoken": csrftoken}, # Re-use CSRF from a valid page
+        cookies=cookies,
+    )
+    # When chronicle is enabled on an empty table, _chronicle_empty_stuff is created but has 0 rows.
+    # Max version should be 0.
+    response_empty = await datasette.client.get(f"/test_body/{empty_table_name}", cookies=cookies)
+    assert response_empty.status_code == 200
+    assert 'window.datasette_chronicle_max_version = 0;' in response_empty.text
+    assert f'window.datasette_chronicle_database_name = "test_body";' in response_empty.text
+    assert f'window.datasette_chronicle_table_name = "{empty_table_name}";' in response_empty.text
+
+    chronicle_empty_rows = list(db.query(f"SELECT MAX(__version) as max_v FROM _chronicle_{empty_table_name}"))
+    # MAX of an empty set is NULL in SQL, which our hook converts to 0.
+    assert chronicle_empty_rows[0]["max_v"] is None 
+
+    # Script should not be present if chronicle is not enabled
+    no_chron_table = "no_chron_table"
+    db[no_chron_table].insert({"id": 1, "val": "X"}, pk="id")
+    response_no_chron = await datasette.client.get(f"/test_body/{no_chron_table}", cookies=cookies)
+    assert response_no_chron.status_code == 200
+    assert 'window.datasette_chronicle_max_version =' not in response_no_chron.text
+
+
+@pytest.mark.asyncio
+async def test_chronicle_notification_banner_behavior(datasette_port, page, tmpdir):
+    db_path = str(tmpdir / "test_playwright.db")
+    # We need to initialize Datasette instance ourselves to get its URL for Playwright
+    ds = Datasette([db_path], settings={"base_url": f"http://localhost:{datasette_port}"})
+    await ds.invoke_startup() # Ensure plugins are loaded, including datasette-chronicle
+    
+    db = sqlite_utils.Database(db_path)
+    table_name = "log_entries"
+
+    # Initial table setup
+    db[table_name].create(
+        {"id": int, "message": str, "ts": float},
+        pk="id",
+    )
+    # Enable chronicle BEFORE inserting initial data, so initial inserts get versioned.
+    # sqlite-chronicle's enable_chronicle will also copy existing data into chronicle table.
+    # For a clean test, enable first, then insert.
+    db.conn.execute("VACUUM;") # Ensure connection is fresh before direct manipulation
+    sqlite_chronicle.enable_chronicle(db.conn, table_name)
+
+    # Insert initial data - this will create versions 1, 2, 3
+    db[table_name].insert_all([
+        {"id": 1, "message": "First log", "ts": time.time()},
+        {"id": 2, "message": "Second log", "ts": time.time() + 1},
+        {"id": 3, "message": "Third log", "ts": time.time() + 2},
+    ])
+    
+    initial_max_version = 3
+    chronicle_table_name = f"_chronicle_{table_name}"
+    # Verify chronicle table state
+    assert db[chronicle_table_name].count == initial_max_version
+    max_v_rows = list(db.query(f"SELECT MAX(__version) AS max_v FROM {chronicle_table_name}"))
+    assert max_v_rows[0]["max_v"] == initial_max_version
+
+    table_url = ds.urls.table("test_playwright", table_name)
+
+    # --- Scenario 1: First visit ---
+    await page.goto(table_url)
+    
+    # Banner should NOT be visible on first visit
+    await page.wait_for_selector(".chronicle-notification-banner", state="hidden")
+
+    # Check localStorage
+    ls_key = f"chronicle_last_seen_info_test_playwright_{table_name}"
+    stored_info_s1 = await page.evaluate(f"localStorage.getItem('{ls_key}')")
+    assert stored_info_s1 is not None
+    stored_info_s1_data = json.loads(stored_info_s1)
+    assert stored_info_s1_data["version"] == initial_max_version
+    assert "timestamp" in stored_info_s1_data
+
+    # --- Scenario 2: Subsequent visit, no changes ---
+    await page.goto(table_url) # Reload page
+    await page.wait_for_selector(".chronicle-notification-banner", state="hidden")
+    
+    stored_info_s2 = await page.evaluate(f"localStorage.getItem('{ls_key}')")
+    assert stored_info_s2 is not None
+    stored_info_s2_data = json.loads(stored_info_s2)
+    assert stored_info_s2_data["version"] == initial_max_version # Version should be the same
+
+    # --- Scenario 3: Subsequent visit, with changes ---
+    # Add more data to the table
+    db[table_name].insert_all([
+        {"id": 4, "message": "Fourth log", "ts": time.time() + 3}, # Version 4
+        {"id": 5, "message": "Fifth log", "ts": time.time() + 4},   # Version 5
+    ])
+    new_max_version = 5
+    assert db[chronicle_table_name].count == new_max_version
+    max_v_rows_s3 = list(db.query(f"SELECT MAX(__version) AS max_v FROM {chronicle_table_name}"))
+    assert max_v_rows_s3[0]["max_v"] == new_max_version
+    
+    await page.goto(table_url) # Reload page
+
+    # Banner SHOULD be visible now
+    banner = await page.wait_for_selector(".chronicle-notification-banner")
+    assert banner is not None
+    banner_text = await banner.text_content()
+    
+    # 2 new rows (5 - 3 = 2)
+    # The exact "time since" text can be flaky, so check for the core message part
+    assert "2 row(s) updated" in banner_text 
+    # Example: "2 row(s) updated since your last visit recently." or "... X day(s) ago."
+
+    # Check localStorage updated
+    stored_info_s3 = await page.evaluate(f"localStorage.getItem('{ls_key}')")
+    assert stored_info_s3 is not None
+    stored_info_s3_data = json.loads(stored_info_s3)
+    assert stored_info_s3_data["version"] == new_max_version
+    assert stored_info_s3_data["timestamp"] > stored_info_s1_data["timestamp"]
+    
+    # --- Scenario 4: Visit again after seeing changes, banner should be gone ---
+    await page.goto(table_url)
+    await page.wait_for_selector(".chronicle-notification-banner", state="hidden")
+    
+    # LocalStorage version should remain new_max_version
+    stored_info_s4 = await page.evaluate(f"localStorage.getItem('{ls_key}')")
+    assert stored_info_s4 is not None
+    stored_info_s4_data = json.loads(stored_info_s4)
+    assert stored_info_s4_data["version"] == new_max_version
+    
+    await ds.client.session.close() # Close datasette client


### PR DESCRIPTION
Here's what https://jules.google.com/ produced when I pasted in the full markdown of #3, exported using https://tools.simonwillison.net/github-issue-to-markdown

I have not yet reviewed this code.

It said:

> I've implemented a mechanism to notify you about table row updates that occurred since your last visit to a specific table page.
> 
> Key changes:
> - I introduced `extra_js_urls`, `extra_head_html`, and `extra_body_script` hooks in `datasette_chronicle/__init__.py`.
>   - `extra_body_script` injects the current maximum version ID of the chronicle table, along with database and table names, into a JavaScript variable on the table page.
>   - `extra_js_urls` links a new static JavaScript file.
>   - `extra_head_html` injects CSS for styling the notification banner.
> - I added `datasette_chronicle/static/datasette_chronicle.js`, which:
>   - Reads the max version from the injected variable.
>   - Stores and retrieves the last seen version and timestamp for the table from `localStorage`.
>   - If the current max version is newer, it fetches the count of updated rows using the existing `?_since=` API.
>   - Displays a banner at the top of the page showing the number of new rows and the time since your last visit.
>   - Updates `localStorage` with the new max version and timestamp.
> - I added comprehensive tests in `tests/test_chronicle.py`:
>   - Unit tests for the new Python hooks.
>   - Playwright end-to-end tests to verify the JavaScript behavior, including `localStorage` interactions and banner display under various scenarios (first visit, no changes, new changes).
> 
> This feature enhances your awareness of data changes within Datasette tables that have chronicle enabled.